### PR TITLE
Add support for Ed25519/Ed448 keys and improve certificate extensions

### DIFF
--- a/cheetahpki/createSelfSignedRootCert.py
+++ b/cheetahpki/createSelfSignedRootCert.py
@@ -4,6 +4,8 @@ from cryptography.x509.oid import NameOID
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PrivateKey
 import datetime
 import uuid
 import re
@@ -13,6 +15,12 @@ from .exceptions import (
     PrivateKeyLoadError,
     CertificateSaveError
 )
+
+def _signing_hash(private_key):
+    """Retourne l'algorithme de hachage adapté au type de clé privée."""
+    if isinstance(private_key, (Ed25519PrivateKey, Ed448PrivateKey)):
+        return None  # Ed25519/Ed448 gèrent le hachage en interne
+    return hashes.SHA256()
 
 def is_valid_email(email):
     """ Vérifie si l'email a un format valide. """
@@ -123,7 +131,7 @@ def createSelfSignedRootCert(pseudo:str, company:str, city:str, region:str, coun
         critical=False
     ).sign(
         private_key=private_key,
-        algorithm=hashes.SHA256(),
+        algorithm=_signing_hash(private_key),
         backend=default_backend()
     )
 

--- a/cheetahpki/createSignedCert.py
+++ b/cheetahpki/createSignedCert.py
@@ -4,6 +4,10 @@ from cryptography.x509.oid import NameOID
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PrivateKey, Ed448PublicKey
 import datetime
 import re
 
@@ -15,6 +19,37 @@ from .exceptions import (
     CertificateLoadError,
     CertificateSaveError
 )
+
+def _signing_hash(private_key):
+    """Retourne l'algorithme de hachage adapté au type de clé privée."""
+    if isinstance(private_key, (Ed25519PrivateKey, Ed448PrivateKey)):
+        return None
+    return hashes.SHA256()
+
+def _end_entity_key_usage(public_key):
+    """Retourne les paramètres KeyUsage adaptés au type de clé publique."""
+    if isinstance(public_key, RSAPublicKey):
+        return x509.KeyUsage(
+            digital_signature=True, key_cert_sign=False, crl_sign=False,
+            key_encipherment=True, data_encipherment=True,
+            content_commitment=False, key_agreement=False,
+            encipher_only=False, decipher_only=False
+        )
+    elif isinstance(public_key, EllipticCurvePublicKey):
+        return x509.KeyUsage(
+            digital_signature=True, key_cert_sign=False, crl_sign=False,
+            key_encipherment=False, data_encipherment=False,
+            content_commitment=False, key_agreement=True,
+            encipher_only=False, decipher_only=False
+        )
+    else:
+        # Ed25519 / Ed448 : signature uniquement
+        return x509.KeyUsage(
+            digital_signature=True, key_cert_sign=False, crl_sign=False,
+            key_encipherment=False, data_encipherment=False,
+            content_commitment=False, key_agreement=False,
+            encipher_only=False, decipher_only=False
+        )
 
 def is_valid_email(email):
     """ Vérifie si l'email a un format valide. """
@@ -131,29 +166,21 @@ def createSignedCert(public_key_path:str, pseudo:str, company:str, department:st
 
     # Préparer les extensions
     extensions = [
-        x509.BasicConstraints(ca=False, path_length=None),
-        x509.KeyUsage(
-            digital_signature=True,
-            key_cert_sign=False,
-            crl_sign=False,
-            key_encipherment=True,
-            data_encipherment=True,
-            content_commitment=False,
-            key_agreement=False,
-            encipher_only=False,
-            decipher_only=False
-        ),
-        x509.ExtendedKeyUsage([
+        (x509.BasicConstraints(ca=False, path_length=None), True),
+        (_end_entity_key_usage(public_key), True),
+        (x509.ExtendedKeyUsage([
             x509.oid.ExtendedKeyUsageOID.SERVER_AUTH,
             x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH
-        ]),
-        x509.SubjectAlternativeName(
+        ]), False),
+        (x509.SubjectAlternativeName(
             [x509.RFC822Name(email)] +
             [x509.DNSName(name) for name in alt_names or []] +
             [x509.IPAddress(ipaddress.ip_address(ip)) for ip in ip_addresses or []]
-        )
+        ), False),
+        (x509.SubjectKeyIdentifier.from_public_key(public_key), False),
+        (x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_private_key.public_key()), False),
     ]
-    
+
     # Construction du certificat utilisateur
     certificate_builder = x509.CertificateBuilder().subject_name(
         subject
@@ -170,13 +197,13 @@ def createSignedCert(public_key_path:str, pseudo:str, company:str, department:st
     )
 
     # Ajouter les extensions
-    for ext in extensions:
-        certificate_builder = certificate_builder.add_extension(ext, critical=False)
+    for ext, critical in extensions:
+        certificate_builder = certificate_builder.add_extension(ext, critical=critical)
 
     # Signer le certificat avec la clé privée de la CA
     certificate = certificate_builder.sign(
         private_key=ca_private_key,
-        algorithm=hashes.SHA256(),
+        algorithm=_signing_hash(ca_private_key),
         backend=default_backend()
     )
 

--- a/cheetahpki/createSignedInterCert.py
+++ b/cheetahpki/createSignedInterCert.py
@@ -4,6 +4,8 @@ from cryptography.x509.oid import NameOID
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PrivateKey
 import datetime
 import re
 
@@ -15,6 +17,12 @@ from .exceptions import (
     CertificateLoadError,
     CertificateSaveError
 )
+
+def _signing_hash(private_key):
+    """Retourne l'algorithme de hachage adapté au type de clé privée."""
+    if isinstance(private_key, (Ed25519PrivateKey, Ed448PrivateKey)):
+        return None
+    return hashes.SHA256()
 
 def is_valid_email(email):
     """ Vérifie si l'email a un format valide. """
@@ -178,7 +186,7 @@ def createSignedInterCert(public_key_path:str, pseudo:str, company:str, departme
     # Signer le certificat avec la clé privée de la CA
     certificate = certificate_builder.sign(
         private_key=ca_private_key,
-        algorithm=hashes.SHA256(),
+        algorithm=_signing_hash(ca_private_key),
         backend=default_backend()
     )
 

--- a/rapports_cheetahpki/rapport_2026-04-19.md
+++ b/rapports_cheetahpki/rapport_2026-04-19.md
@@ -1,0 +1,82 @@
+# Rapport CheetahPKI — 2026-04-19
+
+## ✅ Ce qui a été fait aujourd'hui
+
+**Phase 1 — Jours 4 & 5 : adaptation des fonctions de certificat aux clés EC/Ed**
+
+### `createSelfSignedRootCert.py`
+- Ajout de la fonction interne `_signing_hash(private_key)` : retourne `hashes.SHA256()` pour RSA/ECDSA, `None` pour Ed25519/Ed448 (ces algorithmes gèrent le hachage en interne).
+- Remplacement de l'appel `.sign(algorithm=hashes.SHA256())` par `.sign(algorithm=_signing_hash(private_key))`.
+- La fonction supporte désormais des clés privées RSA, ECDSA (P-256/P-384/P-521), Ed25519 et Ed448.
+
+### `createSignedCert.py`
+- Ajout de `_signing_hash(private_key)` — même logique que ci-dessus, appliquée à la clé CA.
+- Ajout de `_end_entity_key_usage(public_key)` : adapte dynamiquement le KeyUsage selon le type de clé du sujet :
+  - RSA → `key_encipherment=True, data_encipherment=True`
+  - ECDSA → `key_agreement=True`
+  - Ed25519/Ed448 → `digital_signature=True` uniquement
+- Ajout de `SubjectKeyIdentifier` et `AuthorityKeyIdentifier` (absents avant) — requis par RFC 5280.
+- `BasicConstraints` et `KeyUsage` passés en `critical=True` (correction de conformité RFC 5280).
+- Extensions restructurées en liste de tuples `(extension, critical)`.
+
+### `createSignedInterCert.py`
+- Ajout de `_signing_hash(private_key)` et correction de l'appel `.sign()`.
+- La CA root peut désormais être de type EC ou Ed25519/Ed448 pour signer un certificat intermédiaire.
+
+**Fichiers modifiés :**
+- `cheetahpki/createSelfSignedRootCert.py`
+- `cheetahpki/createSignedCert.py`
+- `cheetahpki/createSignedInterCert.py`
+
+**Tests de fumée réussis :**
+- RSA 2048 root → inter RSA → user RSA ✅
+- EC P-256 root → inter P-384 → user EC P-256 ✅
+- Ed25519 root → user RSA (cross-type signing) ✅
+
+---
+
+## 🔬 État des algorithmes supportés
+
+| Algorithme | generateKeyPair | createSelfSignedRootCert | createSignedInterCert | createSignedCert |
+|-----------|----------------|--------------------------|----------------------|-----------------|
+| RSA 2048/4096 | ✅ | ✅ | ✅ | ✅ |
+| ECDSA P-256 | ✅ | ✅ | ✅ | ✅ |
+| ECDSA P-384 | ✅ | ✅ | ✅ | ✅ |
+| ECDSA P-521 | ✅ | ✅ | ✅ | ✅ |
+| Ed25519 | ✅ | ✅ | ✅ | ✅ |
+| Ed448 | ✅ | ✅ | ✅ | ✅ |
+
+---
+
+## 📋 Extensions X.509
+
+| Extension | createSelfSignedRootCert | createSignedInterCert | createSignedCert |
+|-----------|--------------------------|----------------------|-----------------|
+| BasicConstraints (critical) | ✅ | ✅ | ✅ (fixé) |
+| KeyUsage (critical) | ✅ | ✅ | ✅ (fixé) |
+| SubjectKeyIdentifier | ✅ | ✅ | ✅ (ajouté) |
+| AuthorityKeyIdentifier | ❌ (auto-signé, normal) | ✅ | ✅ (ajouté) |
+| ExtendedKeyUsage | ❌ | ✅ | ✅ |
+| SubjectAlternativeName | ❌ | ✅ | ✅ |
+| OCSP (AuthorityInformationAccess) | ❌ | ❌ | ❌ |
+| CRL Distribution Points | ❌ | ❌ | ❌ |
+
+---
+
+## 🔜 Prochaine étape
+
+**Phase 2 — Jour 6 :** Injecter `AuthorityInformationAccess` (OCSP URL) dans `createSignedCert.py` via un paramètre optionnel `ocsp_url: str = None`.
+
+---
+
+## ⚠️ Problèmes ou blocages
+
+RAS. Le module `_cffi_backend` manque dans `/usr/local/bin/python3` (Python 3.11.15), mais Python 3.12 (`/usr/bin/python3.12`) fonctionne correctement avec la bibliothèque `cryptography`.
+
+---
+
+## 📊 Avancement global estimé
+
+Phase 1 (Algorithmes) : **5/5 jours** — COMPLÈTE ✅
+Phase 2 (Extensions X.509) : **0/5 jours** — SKI/AKI dans createSignedCert ajoutés en bonus aujourd'hui
+Phase 3 (Qualité & API) : **0/∞ jours**


### PR DESCRIPTION
## Summary
This PR adds support for EdDSA key types (Ed25519 and Ed448) across the certificate generation modules and improves certificate extension handling with proper criticality flags and additional extensions.

## Key Changes

- **EdDSA Support**: Added imports and handling for Ed25519 and Ed448 private/public keys in all three certificate generation modules
- **Hash Algorithm Abstraction**: Introduced `_signing_hash()` helper function that returns `None` for EdDSA keys (which handle hashing internally) and `SHA256()` for RSA/EC keys
- **Key Usage Extension Logic**: Created `_end_entity_key_usage()` function that returns appropriate KeyUsage parameters based on key type:
  - RSA: supports digital_signature, key_encipherment, data_encipherment
  - EC: supports digital_signature, key_agreement
  - EdDSA: supports digital_signature only
- **Enhanced Certificate Extensions**: 
  - Added SubjectKeyIdentifier and AuthorityKeyIdentifier extensions
  - Properly set criticality flags for each extension (BasicConstraints is critical, others are non-critical)
  - Changed extension handling to use tuples of (extension, critical_flag)
- **Code Refactoring**: Replaced hardcoded SHA256 algorithm with dynamic `_signing_hash()` calls in certificate signing operations

## Implementation Details

The `_signing_hash()` function is duplicated across modules to maintain module independence. EdDSA algorithms (Ed25519/Ed448) require `None` as the hash algorithm parameter since they perform deterministic hashing internally, unlike RSA and EC which require an explicit hash algorithm.

The KeyUsage extension now adapts based on the public key type to ensure certificates reflect the actual cryptographic capabilities of their keys.

https://claude.ai/code/session_019Nc2QaZoxx9xy4YdPmPqeD